### PR TITLE
Fixing hard coded table name

### DIFF
--- a/magmi/plugins/extra/itemprocessors/groupprice/grouppriceprocessor.php
+++ b/magmi/plugins/extra/itemprocessors/groupprice/grouppriceprocessor.php
@@ -127,7 +127,7 @@ class GrouppriceProcessor extends Magmi_ItemProcessor
         $sql = 'SELECT value FROM ' . $this->tablename('core_config_data') . ' WHERE path = ?';
         $this->_priceScope = intval($this->selectone($sql, array('catalog/price/scope'), 'value'));
         /* Getting customer tax class */
-        $sql="SELECT class_id FROM tax_class WHERE class_type='CUSTOMER'";
+        $sql="SELECT class_id FROM ".$this->tablename('tax_class')." WHERE class_type='CUSTOMER'";
         $this->_tax_class_id=$this->selectone($sql,null,'class_id');
         
     }


### PR DESCRIPTION
If your tables had a prefix, the hard coded table name caused the import to break.